### PR TITLE
GraphQL upgrade and deterministic enum mocks

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
   },
   "dependencies": {
     "fast-json-stable-stringify": "^2.1.0",
-    "graphql": "^15.0.0",
+    "graphql": "^16.9.0",
     "seedrandom": "^3.0.5"
   }
 }

--- a/src/__tests__/lib.test.ts
+++ b/src/__tests__/lib.test.ts
@@ -3,6 +3,8 @@ import { GraphQLError } from "graphql";
 import schema from "./schema";
 import schemaAST from "./schema-ast.json";
 
+const seed = 'seed';
+
 describe("Automocking", () => {
   describe("Guardrails", () => {
     test("it throws without a valid schema", () => {
@@ -89,10 +91,15 @@ describe("Automocking", () => {
           returnEnum
         }
       `;
-      const resp: any = ergonomock(schema, testQuery);
+      const resp: any = ergonomock(schema, testQuery, { seed });
       expect(resp.data).toMatchObject({
         returnEnum: expect.toBeOneOf(["A", "B", "C"]),
       });
+
+      for (let i = 0; i < 10; ++i) {
+        const resp2 = ergonomock(schema, testQuery, { seed });
+        expect(resp).toEqual(resp2);
+      }
     });
 
     test("can automock unions", () => {

--- a/src/mock.ts
+++ b/src/mock.ts
@@ -3,7 +3,6 @@ import {
   parse,
   execute,
   GraphQLType,
-  GraphQLObjectType,
   GraphQLInterfaceType,
   GraphQLUnionType,
   getNamedType,
@@ -190,7 +189,7 @@ function assignResolveType(type: GraphQLType) {
     // the default `resolveType` always returns null. We add a fallback
     // resolution that works with how unions and interface are mocked
     namedFieldType.resolveType = (data: any, context: any, info: GraphQLResolveInfo) => {
-      return info.schema.getType(data.__typename) as GraphQLObjectType;
+      return info.schema.getType(data.__typename)?.name;
     };
   }
 }

--- a/src/mock.ts
+++ b/src/mock.ts
@@ -19,7 +19,6 @@ import {
   buildASTSchema,
 } from "graphql";
 import random from "./utils/random";
-import getRandomElement from "./utils/getRandomElement";
 import forEachFieldInQuery from "./utils/forEachFieldInQuery";
 
 const defaultMockMap: Map<string, GraphQLFieldResolver<any, any>> = new Map();
@@ -117,7 +116,7 @@ export function ergonomock(
       if (fieldType instanceof GraphQLUnionType || fieldType instanceof GraphQLInterfaceType) {
         let implementationType;
         const possibleTypes = schema.getPossibleTypes(fieldType);
-        implementationType = getRandomElement(possibleTypes);
+        implementationType = random.item(possibleTypes);
         return Object.assign(
           { __typename: implementationType },
           mockResolverFunction(implementationType)(root, args, context, info)
@@ -130,7 +129,7 @@ export function ergonomock(
 
       // Default mock for enums
       if (fieldType instanceof GraphQLEnumType) {
-        return getRandomElement(fieldType.getValues()).value;
+        return random.item(fieldType.getValues()).value;
       }
 
       // Automock object types

--- a/src/utils/forEachFieldInQuery.ts
+++ b/src/utils/forEachFieldInQuery.ts
@@ -33,7 +33,7 @@ export default function forEachFieldInQuery(
         if (isAbstractType(parentType)) {
           const possibleTypes = schema.getPossibleTypes(parentType);
           possibleTypes.forEach(t => {
-            const fieldDef = getFieldDef(schema, t, fieldName);
+            const fieldDef = getFieldDef(schema, t, node);
             if (fieldDef) {
               fn(fieldDef, t.name, fieldName);
             }

--- a/src/utils/getRandomElement.ts
+++ b/src/utils/getRandomElement.ts
@@ -1,4 +1,0 @@
-export default function getRandomElement(ary: ReadonlyArray<any>) {
-  const sample = Math.floor(Math.random() * ary.length);
-  return ary[sample];
-}

--- a/src/utils/random.ts
+++ b/src/utils/random.ts
@@ -252,6 +252,8 @@ const random = {
   // max is exclusive, min is inclusive
   float: (max: number = 100, min: number = 1) => rng() * (max - min) + min,
 
+  item: <T>(array: readonly T[]): T => array[random.integer(array.length, 0)],
+
   // max and min are inclusive
   list: (maxLength: number = 4, minLength: number = 1) => [
     ...Array(random.integer(maxLength + 1, minLength))

--- a/yarn.lock
+++ b/yarn.lock
@@ -2964,10 +2964,10 @@ graphql-tag@^2.12.3:
   dependencies:
     tslib "^2.1.0"
 
-graphql@^15.0.0:
-  version "15.0.0"
-  resolved "https://registry.npmjs.org/graphql/-/graphql-15.0.0.tgz"
-  integrity sha512-ZyVO1xIF9F+4cxfkdhOJINM+51B06Friuv4M66W7HzUOeFd+vNzUn4vtswYINPi6sysjf1M2Ri/rwZALqgwbaQ==
+graphql@^16.9.0:
+  version "16.9.0"
+  resolved "https://registry.yarnpkg.com/graphql/-/graphql-16.9.0.tgz#1c310e63f16a49ce1fbb230bd0a000e99f6f115f"
+  integrity sha512-GGTKBX4SD7Wdb8mqeDLni2oaRGYQWjWHGKPQ24ZMnUtKfcsVoiv4uX8+LJr1K6U5VW2Lu1BwJnj7uiori0YtRw==
 
 growly@^1.3.0:
   version "1.3.0"


### PR DESCRIPTION
* Upgrade `graphql` package to v16
* Made enum mocks always return the same value instead of different values very test run